### PR TITLE
migrate entirely to conda-forge

### DIFF
--- a/polarityjam-app.yml
+++ b/polarityjam-app.yml
@@ -1,12 +1,10 @@
 name: polarityjam-app
 channels:
   - conda-forge
-  - defaults
-  - r
 dependencies:
   - python=3.8
   - pip
-  - r-base=4.3.1
+  - r-base=4.3.3
   - r-pacman=0.5.1
   - r-shiny=1.7.5.1
   - r-shinyfiles=0.9.3


### PR DESCRIPTION
a license change for anaconda software forces almost everyone to move away from anaconda services.

conda-forge is the best alternative. Hence this migration towards conda-forge.

Installation is testet and seems to work.